### PR TITLE
Rework: change theme method

### DIFF
--- a/sbsp_frontend/src/App.vue
+++ b/sbsp_frontend/src/App.vue
@@ -27,6 +27,7 @@ import UpdateDialog from './components/dialog/UpdateDialog.vue';
 import CreditsDialog from './components/dialog/CreditsDialog.vue';
 import LicenseDialog from './components/dialog/LicenseDialog.vue';
 import { useUiState } from './stores/uistate';
+import { setTheme } from '@tauri-apps/api/app';
 
 const { locale } = useI18n({ useScope: 'global' });
 const windowMenu = createWindowMenu();
@@ -44,7 +45,11 @@ watch(
       setLanguage(newSettings.language);
     }
     if (newSettings.darkMode != oldSettings.darkMode) {
-      theme.change(newSettings.darkMode);
+      if (target == 'tauri') {
+        setTheme(newSettings.darkMode == 'system' ? null : newSettings.darkMode);
+      } else {
+        theme.change(newSettings.darkMode);
+      }
     }
   },
 );
@@ -67,7 +72,11 @@ const setLanguage = (language: string | null) => {
 
 onMounted(() => {
   setLanguage(uiSettings.settings.appearance.language);
-  theme.change(uiSettings.settings.appearance.darkMode);
+  if (target == 'tauri') {
+    setTheme(uiSettings.settings.appearance.darkMode == 'system' ? null : uiSettings.settings.appearance.darkMode);
+  } else {
+    theme.change(uiSettings.settings.appearance.darkMode);
+  }
   windowMenu?.init();
   if (side == 'remote') {
     api.remote

--- a/sbsp_frontend/src/api/index.ts
+++ b/sbsp_frontend/src/api/index.ts
@@ -2,7 +2,7 @@ import { IBackendAdapter } from './interface';
 import { useTauriApi } from './tauri';
 import { useWebsocketApi } from './websocket';
 
-export const target = import.meta.env.VITE_APP_TARGET;
+export const target: 'websocket' | 'tauri' = import.meta.env.VITE_APP_TARGET;
 
 export const side: 'host' | 'remote'
   = target == 'websocket' ? 'remote' : import.meta.env.VITE_APP_SIDE == 'host' ? 'host' : 'remote';

--- a/sbsp_remote/capabilities/default.json
+++ b/sbsp_remote/capabilities/default.json
@@ -8,6 +8,7 @@
     "dialog:default",
     "opener:default",
     "core:window:allow-set-title",
+    "core:app:allow-set-app-theme",
     {
       "identifier": "opener:allow-open-path",
       "allow": [

--- a/sbsp_tauri/capabilities/default.json
+++ b/sbsp_tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "opener:default",
     "core:window:allow-set-title",
     "core:window:allow-destroy",
+    "core:app:allow-set-app-theme",
     {
       "identifier": "opener:allow-open-path",
       "allow": [


### PR DESCRIPTION
Use tauri's native api for theme changing on tauri target.

Vuetify's useTheme is still used on websocket target.