### PR TITLE
fix: start end time input

### DIFF
--- a/sbsp_frontend/src/components/editor/WaveformEditor.vue
+++ b/sbsp_frontend/src/components/editor/WaveformEditor.vue
@@ -8,6 +8,7 @@
           :label="t('main.bottomEditor.timeLevels.startTime')"
           :multiply="metadata?.duration || 1"
           :default-value="0"
+          @update="saveEditorValue"
           @pointerdown.stop
         />
         <v-tooltip target="cursor">
@@ -31,6 +32,7 @@
           :label="t('main.bottomEditor.timeLevels.endTime')"
           :multiply="metadata?.duration || 1"
           :default-value="1"
+          @update="saveEditorValue"
           @pointerdown.stop
         />
         <v-tooltip target="cursor">

--- a/sbsp_frontend/src/components/editor/WaveformEditor.vue
+++ b/sbsp_frontend/src/components/editor/WaveformEditor.vue
@@ -7,7 +7,7 @@
           width="175px"
           :label="t('main.bottomEditor.timeLevels.startTime')"
           :multiply="metadata?.duration || 1"
-          @update="emit('update')"
+          :default-value="0"
           @pointerdown.stop
         />
         <v-tooltip target="cursor">
@@ -30,7 +30,7 @@
           width="175px"
           :label="t('main.bottomEditor.timeLevels.endTime')"
           :multiply="metadata?.duration || 1"
-          @update="emit('update')"
+          :default-value="1"
           @pointerdown.stop
         />
         <v-tooltip target="cursor">

--- a/sbsp_frontend/src/components/input/TimeInput.vue
+++ b/sbsp_frontend/src/components/input/TimeInput.vue
@@ -27,11 +27,13 @@ const props = withDefaults(
     acceptMinus?: boolean;
     multiply?: number;
     max?: number | null;
+    defaultValue?: number;
   }>(),
   {
     max: null,
     multiply: 1,
     acceptMinus: false,
+    defaultValue: 0,
   },
 );
 const emit = defineEmits(['update']);
@@ -43,7 +45,12 @@ watch([seconds, () => props.multiply], () => {
 });
 
 const save = () => {
-  let innerValue = formatToSeconds(formattedValue.value, props.acceptMinus) / props.multiply;
+  let innerValue: number;
+  if (formattedValue.value.trim() == '') {
+    innerValue = props.defaultValue;
+  } else {
+    innerValue = formatToSeconds(formattedValue.value, props.acceptMinus) / props.multiply;
+  }
   if (props.max != null && innerValue > props.max) {
     innerValue = props.max;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time input fields now support configurable default values that are applied when the field is cleared.
  * Waveform editor now properly saves and persists edited time range values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Keinsleif/sbsp/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->