### PR TITLE
fix: StopAll, PauseAll, ResumeAll not working correctly with Group cue

### DIFF
--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -104,6 +104,22 @@ impl CueController {
                                         log::error!("Failed to stop active cues before load. {}", e);
                                     }
                                 },
+                                BackendEvent::ShowModelReset{..} => {
+                                    if self.state_tx.borrow().playback_cursor.is_none() {
+                                        let model = self.model_handle.read().await;
+                                        if let Some(first_cue) = model.cues.first() {
+                                            self.state_tx.send_modify(|state| {
+                                                state.playback_cursor = Some(first_cue.id);
+                                            });
+                                        }
+                                    }
+                                    if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
+                                        log::error!("Failed to stop active cues before load. {}", e);
+                                    }
+                                    if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
+                                        log::error!("Failed to stop active cues before load. {}", e);
+                                    }
+                                },
                                 BackendEvent::CueRemoved{cue_ids} => {
                                     let state = self.state_tx.borrow().clone();
                                     if let Some(cursor) = state.playback_cursor && cue_ids.contains(&cursor) {

--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -186,8 +186,10 @@ impl CueController {
                 let state = self.state_tx.borrow().clone();
 
                 for cue_id in state.active_cues.keys() {
-                    let executor_command = command.try_all_into_single_executor_command(*cue_id);
-                    self.executor_tx.send(executor_command).await?;
+                    if let Some(cue) = self.model_handle.get_cue_by_id(cue_id).await && !matches!(cue.params, CueParam::Group { .. }) {
+                        let executor_command = command.try_all_into_single_executor_command(*cue_id);
+                        self.executor_tx.send(executor_command).await?;
+                    }
                 }
                 Ok(())
             }

--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -186,7 +186,8 @@ impl CueController {
                 let state = self.state_tx.borrow().clone();
 
                 for cue_id in state.active_cues.keys() {
-                    if let Some(cue) = self.model_handle.get_cue_by_id(cue_id).await && !matches!(cue.params, CueParam::Group { .. }) {
+                    let is_group = self.model_handle.get_cue_by_id(cue_id).await.is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
+                    if !is_group {
                         let executor_command = command.try_all_into_single_executor_command(*cue_id);
                         self.executor_tx.send(executor_command).await?;
                     }

--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -89,11 +89,15 @@ impl CueController {
                         Ok(event) => {
                             match event {
                                 BackendEvent::ShowModelLoaded{..} => {
-                                    if self.state_tx.borrow().playback_cursor.is_none() {
+                                    {
                                         let model = self.model_handle.read().await;
                                         if let Some(first_cue) = model.cues.first() {
                                             self.state_tx.send_modify(|state| {
                                                 state.playback_cursor = Some(first_cue.id);
+                                            });
+                                        } else {
+                                            self.state_tx.send_modify(|state| {
+                                                state.playback_cursor = None;
                                             });
                                         }
                                     }
@@ -105,14 +109,9 @@ impl CueController {
                                     }
                                 },
                                 BackendEvent::ShowModelReset{..} => {
-                                    if self.state_tx.borrow().playback_cursor.is_none() {
-                                        let model = self.model_handle.read().await;
-                                        if let Some(first_cue) = model.cues.first() {
-                                            self.state_tx.send_modify(|state| {
-                                                state.playback_cursor = Some(first_cue.id);
-                                            });
-                                        }
-                                    }
+                                    self.state_tx.send_modify(|state| {
+                                        state.playback_cursor = None;
+                                    });
                                     if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
                                         log::error!("Failed to stop active cues before load. {}", e);
                                     }

--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -113,10 +113,10 @@ impl CueController {
                                         state.playback_cursor = None;
                                     });
                                     if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
-                                        log::error!("Failed to stop active cues before load. {}", e);
+                                        log::error!("Failed to stop active cues before reset. {}", e);
                                     }
                                     if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
-                                        log::error!("Failed to stop active cues before load. {}", e);
+                                        log::error!("Failed to stop active cues before reset. {}", e);
                                     }
                                 },
                                 BackendEvent::CueRemoved{cue_ids} => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated playback cursor behavior: it now initializes to the first cue when a model loads (or clears when there are no cues).
  * Improved model reset: the playback cursor is cleared and all active cues are stopped reliably after reset.
  * Enhanced pause, resume, and stop handling: group cues are skipped only when confirmed, and missing cues no longer block sending commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->