### PR TITLE
fix(backend): add hostname logic for macOS

### DIFF
--- a/sbsp_backend/src/api/server.rs
+++ b/sbsp_backend/src/api/server.rs
@@ -130,10 +130,22 @@ pub async fn start_apiserver(
 }
 
 pub fn get_mdns_hostname() -> anyhow::Result<String> {
-    gethostname()
+    let hostname_os = gethostname();
+    let hostname_str = hostname_os
         .to_str()
-        .ok_or_else(|| anyhow::anyhow!("failed to get hostname."))
-        .map(|hostname| format!("{}.local.", hostname))
+        .ok_or_else(|| anyhow::anyhow!("failed to get hostname."))?;
+
+    let lower = hostname_str.to_lowercase();
+
+    let mdns_hostname = if lower.ends_with(".local.") {
+        hostname_str.to_string()
+    } else if lower.ends_with(".local") {
+        format!("{}.", hostname_str)
+    } else {
+        format!("{}.local.", hostname_str)
+    } as String;
+
+    Ok(mdns_hostname)
 }
 
 async fn websocket_handler(

--- a/sbsp_backend/src/api/server.rs
+++ b/sbsp_backend/src/api/server.rs
@@ -135,17 +135,16 @@ pub fn get_mdns_hostname() -> anyhow::Result<String> {
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("failed to get hostname."))?;
 
+    Ok(normalize_hostname(hostname_str))
+}
+
+fn normalize_hostname(hostname_str: &str) -> String {
     let lower = hostname_str.to_lowercase();
-
-    let mdns_hostname = if lower.ends_with(".local.") {
-        hostname_str.to_string()
-    } else if lower.ends_with(".local") {
-        format!("{}.", hostname_str)
-    } else {
-        format!("{}.local.", hostname_str)
-    } as String;
-
-    Ok(mdns_hostname)
+    let base = lower
+        .trim_end_matches('.')
+        .strip_suffix(".local")
+        .unwrap_or(lower.trim_end_matches('.'));
+    format!("{}.local.", base)
 }
 
 async fn websocket_handler(
@@ -540,4 +539,31 @@ async fn get_dirs(root_dir: PathBuf, parent: Option<PathBuf>) -> anyhow::Result<
         }
     }
     Ok(root_list)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn mdns_hostname() {
+        // without .local.
+        assert_eq!(normalize_hostname("testpc"), "testpc.local.");
+        // with .local
+        assert_eq!(normalize_hostname("testpc.local"), "testpc.local.");
+        // with .local.
+        assert_eq!(normalize_hostname("testpc.local."), "testpc.local.");
+
+        // case insensitivity
+        assert_eq!(normalize_hostname("TEST-PC.LOCAL."), "test-pc.local.");
+        assert_eq!(normalize_hostname("TEST-PC.LOCAL"), "test-pc.local.");
+
+        // edge cases
+        assert_eq!(normalize_hostname("testpc..."), "testpc.local.");
+        assert_eq!(normalize_hostname(""), ".local.");
+
+        // multibyte
+        assert_eq!(normalize_hostname("テストPC"), ".local.");
+        assert_eq!(normalize_hostname("テストPC.local"), ".local.");
+        assert_eq!(normalize_hostname("テストPC.local."), ".local.");
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mDNS hostname normalization to correctly preserve existing `.local`/`.local.` suffixes.
  * Added consistent formatting for mDNS-ready names, including case-insensitive handling and safer trailing-dot behavior.
  * Kept existing error behavior when the system hostname can’t be read.
  * Added unit test coverage for edge cases such as empty and multibyte hostnames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->