### PR TITLE
fix(frontend): prebump fix part2

### DIFF
--- a/sbsp_frontend/src/components/input/CueSelect.vue
+++ b/sbsp_frontend/src/components/input/CueSelect.vue
@@ -81,7 +81,7 @@ const onHide = () => {
       @hide="onHide"
     >
       <template #value="innerProps">
-        {{ cueList.find((opt) => opt.value === (innerProps.value || null))?.name || ' ' }}
+        {{ cueList.find((opt) => opt.value === (innerProps.value || null))?.name || '&nbsp;' }}
       </template>
     </Select>
     <label>{{ props.label }}</label>

--- a/sbsp_frontend/src/components/input/CueSelect.vue
+++ b/sbsp_frontend/src/components/input/CueSelect.vue
@@ -81,7 +81,7 @@ const onHide = () => {
       @hide="onHide"
     >
       <template #value="innerProps">
-        {{ cueList.find((opt) => opt.value === (innerProps.value || null))?.name || '&nbsp;' }}
+        {{ cueList.find((opt) => opt.value === (innerProps.value || null))?.name || '\u00A0' }}
       </template>
     </Select>
     <label>{{ props.label }}</label>

--- a/sbsp_frontend/src/components/pc/CueListRow.vue
+++ b/sbsp_frontend/src/components/pc/CueListRow.vue
@@ -206,13 +206,19 @@ const closeEditable = (target: EventTarget | null, needSave: boolean, editType: 
         break;
       }
       case 'cuelist_pre_wait': {
-        if (isPreWaitActive.value) return;
+        if (isPreWaitActive.value) {
+          delete target.dataset.prevText;
+          return;
+        }
         const newPreWait = formatToSeconds(target.innerText, false);
         newCue.preWait = newPreWait;
         break;
       }
       case 'cuelist_duration': {
-        if (isPlayingActive.value) return;
+        if (isPlayingActive.value) {
+          delete target.dataset.prevText;
+          return;
+        }
         if (newCue.params.type === 'wait') {
           const newDuration = formatToSeconds(target.innerText, false);
           newCue.params.duration = newDuration;

--- a/sbsp_frontend/src/components/pc/CueListRow.vue
+++ b/sbsp_frontend/src/components/pc/CueListRow.vue
@@ -154,18 +154,16 @@ const openEditable = (e: MouseEvent, editType: string) => {
   }
   if (props.item == null) return;
   if (editType === 'cuelist_duration') {
+    if (isPlayingActive.value) {
+      return;
+    }
     const cueType = props.item.cue.params.type;
     if (cueType !== 'wait' && cueType !== 'fade') {
       return;
     }
   }
-  if (editType === 'cuelist_post_wait') {
-    if (props.item.isChainOverrided) {
-      return;
-    }
-    if (props.item.chain.type !== 'afterStart') {
-      return;
-    }
+  if (editType === 'cuelist_pre_wait' && isPreWaitActive.value) {
+    return;
   }
   e.target.contentEditable = 'true';
   e.target.classList.add('inEdit');
@@ -208,11 +206,13 @@ const closeEditable = (target: EventTarget | null, needSave: boolean, editType: 
         break;
       }
       case 'cuelist_pre_wait': {
+        if (isPreWaitActive.value) return;
         const newPreWait = formatToSeconds(target.innerText, false);
         newCue.preWait = newPreWait;
         break;
       }
       case 'cuelist_duration': {
+        if (isPlayingActive.value) return;
         if (newCue.params.type === 'wait') {
           const newDuration = formatToSeconds(target.innerText, false);
           newCue.params.duration = newDuration;

--- a/sbsp_frontend/src/components/wrapper/SelectWrapper.vue
+++ b/sbsp_frontend/src/components/wrapper/SelectWrapper.vue
@@ -54,7 +54,7 @@ const onHide = () => {
       @hide="onHide"
     >
       <template #value="innerProps">
-        {{ props.items.find((opt) => opt.value === (innerProps.value ?? null))?.name || ' ' }}
+        {{ props.items.find((opt) => opt.value === (innerProps.value ?? null))?.name || '&nbsp;' }}
       </template>
       <template #option="innerProps">
         <div

--- a/sbsp_frontend/src/components/wrapper/SelectWrapper.vue
+++ b/sbsp_frontend/src/components/wrapper/SelectWrapper.vue
@@ -54,7 +54,7 @@ const onHide = () => {
       @hide="onHide"
     >
       <template #value="innerProps">
-        {{ props.items.find((opt) => opt.value === (innerProps.value ?? null))?.name || '&nbsp;' }}
+        {{ props.items.find((opt) => opt.value === (innerProps.value ?? null))?.name || '\u00A0' }}
       </template>
       <template #option="innerProps">
         <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved consistent spacing and select value height when no matching option is available (improves layout stability).
  * Prevented entering duration edit mode for cues that are actively playing.
  * Blocked saving edits for specific cue timing fields when related cue states are active, avoiding unintended timing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->