### PR TITLE
refactor(backend): extract hard stop as command to clarify function

### DIFF
--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -15,12 +15,7 @@ use tokio::sync::{broadcast, mpsc, watch};
 use uuid::Uuid;
 
 use crate::{
-    BackendSettings,
-    controller::state::{ActiveCue, PlaybackStatus, ShowState, StateParam},
-    event::BackendEvent,
-    executor::{ExecutorCommand, ExecutorEvent},
-    manager::ShowModelHandle,
-    model::cue::{CueChain, CueParam, group::GroupMode},
+    BackendSettings, controller::state::{ActiveCue, PlaybackStatus, ShowState, StateParam}, event::BackendEvent, executor::{ExecutorCommand, ExecutorEvent, StopMode}, manager::ShowModelHandle, model::cue::{CueChain, CueParam, group::GroupMode},
 };
 
 pub struct CueController {
@@ -101,21 +96,15 @@ impl CueController {
                                             });
                                         }
                                     }
-                                    if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
-                                        log::error!("Failed to stop active cues before load. {}", e);
-                                    }
-                                    if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
-                                        log::error!("Failed to stop active cues before load. {}", e);
+                                    if let Err(e) = self.hard_stop_all().await {
+                                        log::error!("Failed to stop active cues before reset. {}", e);
                                     }
                                 },
                                 BackendEvent::ShowModelReset{..} => {
                                     self.state_tx.send_modify(|state| {
                                         state.playback_cursor = None;
                                     });
-                                    if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
-                                        log::error!("Failed to stop active cues before reset. {}", e);
-                                    }
-                                    if let Err(e) = self.handle_command(ControllerCommand::StopAll).await {
+                                    if let Err(e) = self.hard_stop_all().await {
                                         log::error!("Failed to stop active cues before reset. {}", e);
                                     }
                                 },
@@ -134,13 +123,9 @@ impl CueController {
                                         }
                                     }
                                     for rm_id in cue_ids {
-                                        if state.active_cues.contains_key(&rm_id) {
-                                            if let Err(e) = self.executor_tx.send(ExecutorCommand::Stop(rm_id)).await {
-                                                log::error!("Failed to stop removed cue. {}", e);
-                                            }
-                                            if let Err(e) = self.executor_tx.send(ExecutorCommand::Stop(rm_id)).await {
-                                                log::error!("Failed to stop removed cue. {}", e);
-                                            }
+                                        if state.active_cues.contains_key(&rm_id)
+                                            && let Err(e) = self.executor_tx.send(ExecutorCommand::Stop(rm_id, StopMode::Hard)).await {
+                                            log::error!("Failed to stop removed cue. {}", e);
                                         }
                                     }
                                 }
@@ -165,13 +150,13 @@ impl CueController {
     }
 
     async fn handle_command(&self, command: ControllerCommand) -> Result<(), anyhow::Error> {
+        let state = self.state_tx.borrow().clone();
         match command {
             ControllerCommand::Go => {
-                let state = self.state_tx.borrow().clone();
                 let cue_id = if let Some(cursor) = state.playback_cursor {
                     cursor
                 } else {
-                    return Err(anyhow::anyhow!("GO: Playback Cursor is unavailable."));
+                    anyhow::bail!("GO: playback_cursor is unavailable.");
                 };
                 self.handle_go(cue_id).await?;
 
@@ -180,35 +165,131 @@ impl CueController {
                 }
                 Ok(())
             }
-            ControllerCommand::Load(cue_id)
-            | ControllerCommand::SeekTo(cue_id, ..)
-            | ControllerCommand::SeekBy(cue_id, ..)
-            | ControllerCommand::Pause(cue_id)
-            | ControllerCommand::Resume(cue_id)
-            | ControllerCommand::Stop(cue_id)
-            | ControllerCommand::PerformAction(cue_id, ..) => {
+            ControllerCommand::Load(cue_id) => {
                 if self.model_handle.is_cue_exists(&cue_id).await {
-                    let executor_command = command.into_executor_command();
-                    self.executor_tx.send(executor_command).await?;
+                    if !state.active_cues.contains_key(&cue_id) {
+                        self.executor_tx.send(ExecutorCommand::Load(cue_id)).await?;
+                    } else {
+                        anyhow::bail!("Load: cue already executed. cue_id={}", cue_id);
+                    }
                 } else {
-                    anyhow::bail!("DIRECT: Cue not found. cue_id={}", cue_id);
+                    anyhow::bail!("Load: cue not found. cue_id={}", cue_id);
+                }
+                Ok(())
+            }
+            ControllerCommand::SeekTo(cue_id, position) => {
+                if self.model_handle.is_cue_exists(&cue_id).await {
+                    if state.active_cues.contains_key(&cue_id) {
+                        self.executor_tx.send(ExecutorCommand::SeekTo(cue_id, position)).await?;
+                    } else {
+                        anyhow::bail!("SeekTo: cue is not executed. cue_id={}", cue_id);
+                    }
+                } else {
+                    anyhow::bail!("SeekTo: cue not found. cue_id={}", cue_id);
+                }
+                Ok(())
+            }
+            ControllerCommand::SeekBy(cue_id, amount) => {
+                if self.model_handle.is_cue_exists(&cue_id).await {
+                    if state.active_cues.contains_key(&cue_id) {
+                        self.executor_tx.send(ExecutorCommand::SeekBy(cue_id, amount)).await?;
+                    } else {
+                        anyhow::bail!("SeekBy: cue is not executed. cue_id={}", cue_id);
+                    }
+                } else {
+                    anyhow::bail!("SeekBy: cue not found. cue_id={}", cue_id);
+                }
+                Ok(())
+            }
+            ControllerCommand::Pause(cue_id) => {
+                if self.model_handle.is_cue_exists(&cue_id).await {
+                    if let Some(active_cue) = state.active_cues.get(&cue_id) && (active_cue.status == PlaybackStatus::PreWaiting || active_cue.status == PlaybackStatus::Playing) {
+                        self.executor_tx.send(ExecutorCommand::Pause(cue_id)).await?;
+                    } else {
+                        anyhow::bail!("Pause: cue is not playing. cue_id={}", cue_id);
+                    }
+                } else {
+                    anyhow::bail!("Pause: cue not found. cue_id={}", cue_id);
+                }
+                Ok(())
+            }
+            ControllerCommand::Resume(cue_id) => {
+                if self.model_handle.is_cue_exists(&cue_id).await {
+                    if let Some(active_cue) = state.active_cues.get(&cue_id) && (active_cue.status == PlaybackStatus::PreWaitPaused || active_cue.status == PlaybackStatus::Paused) {
+                        self.executor_tx.send(ExecutorCommand::Resume(cue_id)).await?;
+                    } else {
+                        anyhow::bail!("Resume: cue is not paused. cue_id={}", cue_id);
+                    }
+                } else {
+                    anyhow::bail!("Resume: cue not found. cue_id={}", cue_id);
+                }
+                Ok(())
+            }
+            ControllerCommand::Stop(cue_id) => {
+                if self.model_handle.is_cue_exists(&cue_id).await {
+                    if let Some(active_cue) = state.active_cues.get(&cue_id) {
+                        let stop_mode = if active_cue.status == PlaybackStatus::Stopping {
+                            StopMode::Hard
+                        } else {
+                            StopMode::Soft
+                        };
+                        self.executor_tx.send(ExecutorCommand::Stop(cue_id, stop_mode)).await?;
+                    }
+                } else {
+                    anyhow::bail!("Stop: cue not found. cue_id={}", cue_id);
+                }
+                Ok(())
+            }
+            ControllerCommand::PerformAction(cue_id, cue_action) => {
+                if self.model_handle.is_cue_exists(&cue_id).await {
+                    if state.active_cues.contains_key(&cue_id) {
+                        self.executor_tx.send(ExecutorCommand::PerformAction(cue_id, cue_action)).await?;
+                    } else {
+                        anyhow::bail!("PerformAction: cue is not executed. cue_id={}", cue_id);
+                    }
+                } else {
+                    anyhow::bail!("PerformAction: cue not found. cue_id={}", cue_id);
                 }
                 Ok(())
             }
             ControllerCommand::PauseAll
             | ControllerCommand::ResumeAll
             | ControllerCommand::StopAll => {
-                let state = self.state_tx.borrow().clone();
-
-                for cue_id in state.active_cues.keys() {
+                for (cue_id, active_cue) in &state.active_cues {
                     let is_group = self
                         .model_handle
                         .get_cue_by_id(cue_id)
                         .await
                         .is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
                     if !is_group {
-                        let executor_command =
-                            command.try_all_into_single_executor_command(*cue_id);
+                        let executor_command = match command {
+                            ControllerCommand::PauseAll => {
+                                match active_cue.status {
+                                    PlaybackStatus::PreWaiting |
+                                    PlaybackStatus::Playing => {
+                                        ExecutorCommand::Pause(*cue_id)
+                                    }
+                                    _ => continue,
+                                }
+                            },
+                            ControllerCommand::ResumeAll => {
+                                match active_cue.status {
+                                    PlaybackStatus::PreWaitPaused |
+                                    PlaybackStatus::Paused => {
+                                        ExecutorCommand::Resume(*cue_id)
+                                    }
+                                    _ => continue,
+                                }
+                            },
+                            ControllerCommand::StopAll => {
+                                if active_cue.status == PlaybackStatus::Stopping {
+                                    ExecutorCommand::Stop(*cue_id, StopMode::Hard)
+                                } else {
+                                    ExecutorCommand::Stop(*cue_id, StopMode::Soft)
+                                }
+                            },
+                            _ => unreachable!(),
+                        };
                         self.executor_tx.send(executor_command).await?;
                     }
                 }
@@ -297,6 +378,21 @@ impl CueController {
         });
         self.event_tx
             .send(BackendEvent::PlaybackCursorMoved { cue_id: cursor })?;
+        Ok(())
+    }
+
+    async fn hard_stop_all(&self) -> Result<()> {
+        let state = self.state_tx.borrow().clone();
+        for cue_id in state.active_cues.keys() {
+            let is_group = self
+                .model_handle
+                .get_cue_by_id(cue_id)
+                .await
+                .is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
+            if !is_group {
+                self.executor_tx.send(ExecutorCommand::Stop(*cue_id, StopMode::Hard)).await?;
+            }
+        }
         Ok(())
     }
 

--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -15,7 +15,12 @@ use tokio::sync::{broadcast, mpsc, watch};
 use uuid::Uuid;
 
 use crate::{
-    BackendSettings, controller::state::{ActiveCue, PlaybackStatus, ShowState, StateParam}, event::BackendEvent, executor::{ExecutorCommand, ExecutorEvent, StopMode}, manager::ShowModelHandle, model::cue::{CueChain, CueParam, group::GroupMode},
+    BackendSettings,
+    controller::state::{ActiveCue, PlaybackStatus, ShowState, StateParam},
+    event::BackendEvent,
+    executor::{ExecutorCommand, ExecutorEvent, StopMode},
+    manager::ShowModelHandle,
+    model::cue::{CueChain, CueParam, group::GroupMode},
 };
 
 pub struct CueController {
@@ -180,7 +185,9 @@ impl CueController {
             ControllerCommand::SeekTo(cue_id, position) => {
                 if self.model_handle.is_cue_exists(&cue_id).await {
                     if state.active_cues.contains_key(&cue_id) {
-                        self.executor_tx.send(ExecutorCommand::SeekTo(cue_id, position)).await?;
+                        self.executor_tx
+                            .send(ExecutorCommand::SeekTo(cue_id, position))
+                            .await?;
                     } else {
                         anyhow::bail!("SeekTo: cue is not executed. cue_id={}", cue_id);
                     }
@@ -192,7 +199,9 @@ impl CueController {
             ControllerCommand::SeekBy(cue_id, amount) => {
                 if self.model_handle.is_cue_exists(&cue_id).await {
                     if state.active_cues.contains_key(&cue_id) {
-                        self.executor_tx.send(ExecutorCommand::SeekBy(cue_id, amount)).await?;
+                        self.executor_tx
+                            .send(ExecutorCommand::SeekBy(cue_id, amount))
+                            .await?;
                     } else {
                         anyhow::bail!("SeekBy: cue is not executed. cue_id={}", cue_id);
                     }
@@ -203,8 +212,13 @@ impl CueController {
             }
             ControllerCommand::Pause(cue_id) => {
                 if self.model_handle.is_cue_exists(&cue_id).await {
-                    if let Some(active_cue) = state.active_cues.get(&cue_id) && (active_cue.status == PlaybackStatus::PreWaiting || active_cue.status == PlaybackStatus::Playing) {
-                        self.executor_tx.send(ExecutorCommand::Pause(cue_id)).await?;
+                    if let Some(active_cue) = state.active_cues.get(&cue_id)
+                        && (active_cue.status == PlaybackStatus::PreWaiting
+                            || active_cue.status == PlaybackStatus::Playing)
+                    {
+                        self.executor_tx
+                            .send(ExecutorCommand::Pause(cue_id))
+                            .await?;
                     } else {
                         anyhow::bail!("Pause: cue is not playing. cue_id={}", cue_id);
                     }
@@ -215,8 +229,13 @@ impl CueController {
             }
             ControllerCommand::Resume(cue_id) => {
                 if self.model_handle.is_cue_exists(&cue_id).await {
-                    if let Some(active_cue) = state.active_cues.get(&cue_id) && (active_cue.status == PlaybackStatus::PreWaitPaused || active_cue.status == PlaybackStatus::Paused) {
-                        self.executor_tx.send(ExecutorCommand::Resume(cue_id)).await?;
+                    if let Some(active_cue) = state.active_cues.get(&cue_id)
+                        && (active_cue.status == PlaybackStatus::PreWaitPaused
+                            || active_cue.status == PlaybackStatus::Paused)
+                    {
+                        self.executor_tx
+                            .send(ExecutorCommand::Resume(cue_id))
+                            .await?;
                     } else {
                         anyhow::bail!("Resume: cue is not paused. cue_id={}", cue_id);
                     }
@@ -233,7 +252,9 @@ impl CueController {
                         } else {
                             StopMode::Soft
                         };
-                        self.executor_tx.send(ExecutorCommand::Stop(cue_id, stop_mode)).await?;
+                        self.executor_tx
+                            .send(ExecutorCommand::Stop(cue_id, stop_mode))
+                            .await?;
                     }
                 } else {
                     anyhow::bail!("Stop: cue not found. cue_id={}", cue_id);
@@ -243,7 +264,9 @@ impl CueController {
             ControllerCommand::PerformAction(cue_id, cue_action) => {
                 if self.model_handle.is_cue_exists(&cue_id).await {
                     if state.active_cues.contains_key(&cue_id) {
-                        self.executor_tx.send(ExecutorCommand::PerformAction(cue_id, cue_action)).await?;
+                        self.executor_tx
+                            .send(ExecutorCommand::PerformAction(cue_id, cue_action))
+                            .await?;
                     } else {
                         anyhow::bail!("PerformAction: cue is not executed. cue_id={}", cue_id);
                     }
@@ -263,23 +286,17 @@ impl CueController {
                         .is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
                     if !is_group {
                         let executor_command = match command {
-                            ControllerCommand::PauseAll => {
-                                match active_cue.status {
-                                    PlaybackStatus::PreWaiting |
-                                    PlaybackStatus::Playing => {
-                                        ExecutorCommand::Pause(*cue_id)
-                                    }
-                                    _ => continue,
+                            ControllerCommand::PauseAll => match active_cue.status {
+                                PlaybackStatus::PreWaiting | PlaybackStatus::Playing => {
+                                    ExecutorCommand::Pause(*cue_id)
                                 }
+                                _ => continue,
                             },
-                            ControllerCommand::ResumeAll => {
-                                match active_cue.status {
-                                    PlaybackStatus::PreWaitPaused |
-                                    PlaybackStatus::Paused => {
-                                        ExecutorCommand::Resume(*cue_id)
-                                    }
-                                    _ => continue,
+                            ControllerCommand::ResumeAll => match active_cue.status {
+                                PlaybackStatus::PreWaitPaused | PlaybackStatus::Paused => {
+                                    ExecutorCommand::Resume(*cue_id)
                                 }
+                                _ => continue,
                             },
                             ControllerCommand::StopAll => {
                                 if active_cue.status == PlaybackStatus::Stopping {
@@ -287,7 +304,7 @@ impl CueController {
                                 } else {
                                     ExecutorCommand::Stop(*cue_id, StopMode::Soft)
                                 }
-                            },
+                            }
                             _ => unreachable!(),
                         };
                         self.executor_tx.send(executor_command).await?;
@@ -390,7 +407,9 @@ impl CueController {
                 .await
                 .is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
             if !is_group {
-                self.executor_tx.send(ExecutorCommand::Stop(*cue_id, StopMode::Hard)).await?;
+                self.executor_tx
+                    .send(ExecutorCommand::Stop(*cue_id, StopMode::Hard))
+                    .await?;
             }
         }
         Ok(())

--- a/sbsp_backend/src/controller/command.rs
+++ b/sbsp_backend/src/controller/command.rs
@@ -6,9 +6,6 @@ use uuid::Uuid;
 
 use crate::action::CueAction;
 
-#[cfg(feature = "backend")]
-use crate::executor::ExecutorCommand;
-
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[cfg_attr(feature = "type_export", derive(ts_rs::TS))]
 #[serde(
@@ -30,29 +27,4 @@ pub enum ControllerCommand {
     StopAll,
     PerformAction(Uuid, CueAction),
     SetPlaybackCursor { cue_id: Option<Uuid> },
-}
-
-#[cfg(feature = "backend")]
-impl ControllerCommand {
-    pub(super) fn into_executor_command(self) -> ExecutorCommand {
-        match self {
-            Self::Pause(uuid) => ExecutorCommand::Pause(uuid),
-            Self::Resume(uuid) => ExecutorCommand::Resume(uuid),
-            Self::Stop(uuid) => ExecutorCommand::Stop(uuid),
-            Self::Load(uuid) => ExecutorCommand::Load(uuid),
-            Self::SeekTo(uuid, position) => ExecutorCommand::SeekTo(uuid, position),
-            Self::SeekBy(uuid, amount) => ExecutorCommand::SeekBy(uuid, amount),
-            Self::PerformAction(uuid, action) => ExecutorCommand::PerformAction(uuid, action),
-            _ => unreachable!(),
-        }
-    }
-
-    pub(super) fn try_all_into_single_executor_command(&self, cue_id: Uuid) -> ExecutorCommand {
-        match self {
-            Self::PauseAll => ExecutorCommand::Pause(cue_id),
-            Self::ResumeAll => ExecutorCommand::Resume(cue_id),
-            Self::StopAll => ExecutorCommand::Stop(cue_id),
-            _ => unreachable!(),
-        }
-    }
 }

--- a/sbsp_backend/src/engine/audio_engine.rs
+++ b/sbsp_backend/src/engine/audio_engine.rs
@@ -297,7 +297,8 @@ impl AudioEngine {
                         }
                         AudioCommand::Pause { id } => self.handle_pause(id).await,
                         AudioCommand::Resume { id } => self.handle_resume(id).await,
-                        AudioCommand::Stop { id } => self.handle_stop(id).await,
+                        AudioCommand::SoftStop { id } => self.handle_stop(id, false).await,
+                        AudioCommand::HardStop { id } => self.handle_stop(id, true).await,
                         AudioCommand::SeekTo { id, position } => self.handle_seek_to(id, position).await,
                         AudioCommand::SeekBy { id, amount } => self.handle_seek_by(id, amount).await,
                         AudioCommand::FadeVolume { id, volume, fade_param } => self.handle_fade_volume(id, volume, fade_param).await,
@@ -527,12 +528,12 @@ impl AudioEngine {
         }
     }
 
-    async fn handle_stop(&mut self, id: Uuid) -> Result<()> {
+    async fn handle_stop(&mut self, id: Uuid, is_hard: bool) -> Result<()> {
         if let Some(playing_sound) = self.playing_sounds.get_mut(&id) {
-            playing_sound.handle.stop();
+            playing_sound.handle.stop(is_hard);
             Ok(())
         } else if let Some(mut loaded_sound) = self.loaded_sounds.remove(&id) {
-            loaded_sound.stop();
+            loaded_sound.stop(is_hard);
             self.event_tx
                 .send(EngineEvent::Audio(AudioEngineEvent::Stopped {
                     instance_id: id,

--- a/sbsp_backend/src/engine/audio_engine/audio_source.rs
+++ b/sbsp_backend/src/engine/audio_engine/audio_source.rs
@@ -114,8 +114,8 @@ enum AudioSourceControlCommand {
     Start,
     Pause,
     Resume,
-    FadeOut,
-    Stop,
+    SoftStop,
+    HardStop,
     Seek {
         position: f64,
         result: oneshot::Sender<Result<(), anyhow::Error>>,
@@ -148,7 +148,6 @@ pub struct AudioSourceHandle {
     pub duration: f64,
     volume: Decibels,
     fade_volume: Decibels,
-    stop_triggered: bool,
 }
 
 impl AudioSourceHandle {
@@ -188,17 +187,15 @@ impl AudioSourceHandle {
         let _ = self.control.push(AudioSourceControlCommand::Pause);
     }
 
-    pub fn stop(&mut self) {
+    pub fn stop(&mut self, is_hard: bool) {
         let state = self.state();
         if state == AudioPlaybackState::Stopped || state == AudioPlaybackState::Completed {
             return;
         }
-        if self.stop_triggered {
-            // Hard Stop
-            let _ = self.control.push(AudioSourceControlCommand::Stop);
+        if is_hard {
+            let _ = self.control.push(AudioSourceControlCommand::HardStop);
         } else {
-            let _ = self.control.push(AudioSourceControlCommand::FadeOut);
-            self.stop_triggered = true;
+            let _ = self.control.push(AudioSourceControlCommand::SoftStop);
         }
     }
 
@@ -464,7 +461,6 @@ where
                 duration,
                 volume: volume_db,
                 fade_volume: Decibels::IDENTITY,
-                stop_triggered: false,
             },
         )
     }
@@ -526,7 +522,7 @@ where
                                     .set_volume(Decibels::IDENTITY, DEFAULT_FADE_PARAM);
                             }
                         }
-                        AudioSourceControlCommand::FadeOut => match state {
+                        AudioSourceControlCommand::SoftStop => match state {
                             AudioPlaybackState::Playing
                             | AudioPlaybackState::Pausing
                             | AudioPlaybackState::Resuming => {
@@ -539,7 +535,7 @@ where
                             }
                             _ => {}
                         },
-                        AudioSourceControlCommand::Stop => match state {
+                        AudioSourceControlCommand::HardStop => match state {
                             AudioPlaybackState::Playing
                             | AudioPlaybackState::Pausing
                             | AudioPlaybackState::Resuming

--- a/sbsp_backend/src/engine/audio_engine/command.rs
+++ b/sbsp_backend/src/engine/audio_engine/command.rs
@@ -29,7 +29,10 @@ pub enum AudioCommand {
     Resume {
         id: Uuid,
     },
-    Stop {
+    SoftStop {
+        id: Uuid,
+    },
+    HardStop {
         id: Uuid,
     },
     SeekTo {
@@ -59,11 +62,13 @@ impl AudioCommand {
             AudioCommand::Play { id, .. } => *id,
             AudioCommand::Pause { id } => *id,
             AudioCommand::Resume { id } => *id,
-            AudioCommand::Stop { id } => *id,
+            AudioCommand::SoftStop { id } => *id,
+            AudioCommand::HardStop { id } => *id,
             AudioCommand::SeekTo { id, .. } => *id,
             AudioCommand::SeekBy { id, .. } => *id,
             AudioCommand::PerformAction { id, .. } => *id,
-            _ => Uuid::nil(),
+            AudioCommand::FadeVolume { id, .. } => *id,
+            AudioCommand::Reconfigure(_) => Uuid::nil(),
         }
     }
 }

--- a/sbsp_backend/src/executor.rs
+++ b/sbsp_backend/src/executor.rs
@@ -697,9 +697,7 @@ impl Executor {
                         StopMode::Soft => AudioCommand::SoftStop { id: cue_id },
                         StopMode::Hard => AudioCommand::HardStop { id: cue_id },
                     };
-                    self.audio_tx
-                        .send(command)
-                        .await?;
+                    self.audio_tx.send(command).await?;
                 }
                 EngineType::Wait => {
                     self.wait_tx
@@ -726,9 +724,7 @@ impl Executor {
                                     StopMode::Soft => AudioCommand::SoftStop { id: *child_id },
                                     StopMode::Hard => AudioCommand::HardStop { id: *child_id },
                                 };
-                                self.audio_tx
-                                    .send(command)
-                                    .await?;
+                                self.audio_tx.send(command).await?;
                                 stop_sent = true;
                             }
                         }

--- a/sbsp_backend/src/executor.rs
+++ b/sbsp_backend/src/executor.rs
@@ -5,6 +5,7 @@ mod command;
 mod event;
 
 pub use command::ExecutorCommand;
+pub use command::StopMode;
 pub use event::ExecutorEvent;
 
 use std::collections::{HashMap, VecDeque};
@@ -123,7 +124,7 @@ impl Executor {
             }
             ExecutorCommand::Pause(cue_id) => self.pause_cue(cue_id).await?,
             ExecutorCommand::Resume(cue_id) => self.resume_cue(cue_id).await?,
-            ExecutorCommand::Stop(cue_id) => self.stop_cue(cue_id).await?,
+            ExecutorCommand::Stop(cue_id, stop_mode) => self.stop_cue(cue_id, stop_mode).await?,
             ExecutorCommand::SeekTo(cue_id, position) => self.seek_to_cue(cue_id, position).await?,
             ExecutorCommand::SeekBy(cue_id, amount) => self.seek_by_cue(cue_id, amount).await?,
             ExecutorCommand::PerformAction(cue_id, action) => {
@@ -446,12 +447,13 @@ impl Executor {
             }
             CueParam::Stop(params) => {
                 if self.active_instances.contains_key(&params.target) {
-                    self.process_command(ExecutorCommand::Stop(params.target))
+                    let stop_mode = if params.hard {
+                        StopMode::Hard
+                    } else {
+                        StopMode::Soft
+                    };
+                    self.process_command(ExecutorCommand::Stop(params.target, stop_mode))
                         .await?;
-                    if params.hard {
-                        self.process_command(ExecutorCommand::Stop(params.target))
-                            .await?;
-                    }
                 }
                 self.executor_event_tx
                     .send(ExecutorEvent::Started {
@@ -679,7 +681,7 @@ impl Executor {
         Ok(())
     }
 
-    async fn stop_cue(&mut self, cue_id: Uuid) -> Result<(), anyhow::Error> {
+    async fn stop_cue(&mut self, cue_id: Uuid, stop_mode: StopMode) -> Result<(), anyhow::Error> {
         if let Some(active_instance) = self.active_instances.get(&cue_id) {
             if active_instance.prewaiting {
                 self.wait_tx
@@ -691,8 +693,12 @@ impl Executor {
             } // continue for stop loaded cue.
             match active_instance.engine_type {
                 EngineType::Audio => {
+                    let command = match stop_mode {
+                        StopMode::Soft => AudioCommand::SoftStop { id: cue_id },
+                        StopMode::Hard => AudioCommand::HardStop { id: cue_id },
+                    };
                     self.audio_tx
-                        .send(AudioCommand::Stop { id: cue_id })
+                        .send(command)
                         .await?;
                 }
                 EngineType::Wait => {
@@ -716,7 +722,12 @@ impl Executor {
                     {
                         for child_id in children.iter() {
                             if self.active_instances.contains_key(child_id) {
-                                self.process_command(ExecutorCommand::Stop(*child_id))
+                                let command = match stop_mode {
+                                    StopMode::Soft => AudioCommand::SoftStop { id: cue_id },
+                                    StopMode::Hard => AudioCommand::HardStop { id: cue_id },
+                                };
+                                self.audio_tx
+                                    .send(command)
                                     .await?;
                                 stop_sent = true;
                             }

--- a/sbsp_backend/src/executor.rs
+++ b/sbsp_backend/src/executor.rs
@@ -723,8 +723,8 @@ impl Executor {
                         for child_id in children.iter() {
                             if self.active_instances.contains_key(child_id) {
                                 let command = match stop_mode {
-                                    StopMode::Soft => AudioCommand::SoftStop { id: cue_id },
-                                    StopMode::Hard => AudioCommand::HardStop { id: cue_id },
+                                    StopMode::Soft => AudioCommand::SoftStop { id: *child_id },
+                                    StopMode::Hard => AudioCommand::HardStop { id: *child_id },
                                 };
                                 self.audio_tx
                                     .send(command)

--- a/sbsp_backend/src/executor/command.rs
+++ b/sbsp_backend/src/executor/command.rs
@@ -6,12 +6,18 @@ use uuid::Uuid;
 use crate::{action::CueAction, model::settings::ShowSettings};
 
 #[derive(Debug)]
+pub enum StopMode {
+    Soft,
+    Hard,
+}
+
+#[derive(Debug)]
 pub enum ExecutorCommand {
     Load(Uuid),
     Execute(Uuid),
     Pause(Uuid),
     Resume(Uuid),
-    Stop(Uuid),
+    Stop(Uuid, StopMode),
     SeekTo(Uuid, f64),
     SeekBy(Uuid, f64),
     PerformAction(Uuid, CueAction),

--- a/sbsp_backend/src/manager/command.rs
+++ b/sbsp_backend/src/manager/command.rs
@@ -16,13 +16,23 @@ use crate::model::{cue::Cue, settings::ShowSettings};
     rename_all_fields = "camelCase"
 )]
 pub enum InsertPosition {
-    Before { target: Uuid },
-    After { target: Uuid },
-    Inside { target: Option<Uuid>, index: Option<usize> },
+    Before {
+        target: Uuid,
+    },
+    After {
+        target: Uuid,
+    },
+    Inside {
+        target: Option<Uuid>,
+        index: Option<usize>,
+    },
 }
 
 impl InsertPosition {
-    pub const LAST: Self = Self::Inside { target: None, index: None };
+    pub const LAST: Self = Self::Inside {
+        target: None,
+        index: None,
+    };
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added soft vs hard stopping so stopping behavior can be more precisely controlled during cue playback.
  * Enhanced controller commands (play, pause/resume, seek, load, stop, and actions) with stricter validation of cue state before execution.
* **Bug Fixes**
  * Active cues are now stopped more reliably when a show is reset or reloaded.
  * Removed cues now stop immediately, reducing any lingering audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->