### PR TITLE
ci: use `--frozen-lockfile` for pnpm install

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -66,7 +66,7 @@ jobs:
           sudo apt-get install -y libasound2-dev # alsa-sys dependencies
 
       - name: install frontend dependencies
-        run: pnpm install # change this to npm, pnpm or bun depending on which one you use.
+        run: pnpm install --frozen-lockfile # change this to npm, pnpm or bun depending on which one you use.
 
       # SBSP
 

--- a/.github/workflows/check-license-notices.yml
+++ b/.github/workflows/check-license-notices.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: install frontend dependencies
-        run: pnpm install # change this to npm, pnpm or bun depending on which one you use.
+        run: pnpm install --frozen-lockfile # change this to npm, pnpm or bun depending on which one you use.
 
       - name: Generate notices
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build with VitePress
         run: pnpm run docs:build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized automated builds, license checks, and documentation deployments to use the locked dependency versions.
  * Improved build consistency by preventing dependency changes during automated installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->