### PR TITLE
fix(frontend): invalid param of ActiveCueItem on MonitorPanel

### DIFF
--- a/sbsp_frontend/src/MainViewMobile.vue
+++ b/sbsp_frontend/src/MainViewMobile.vue
@@ -54,19 +54,19 @@ watch(
     <div class="flex shrink grow flex-col overflow-hidden">
       <div class="flex shrink grow flex-row overflow-hidden">
         <div
-          v-show="activeTab === 'list'"
+          v-if="activeTab === 'list'"
           class="flex h-full w-full overflow-hidden"
         >
           <cue-list />
         </div>
         <div
-          v-show="(uiState.permission & PERMISSIONS.CONTROL) != 0 && activeTab === 'controls'"
+          v-if="(uiState.permission & PERMISSIONS.CONTROL) != 0 && activeTab === 'controls'"
           class="h-full w-full"
         >
           <controls-panel />
         </div>
         <div
-          v-show="activeTab === 'monitor'"
+          v-if="activeTab === 'monitor'"
           class="h-full w-full"
         >
           <monitor-panel />

--- a/sbsp_frontend/src/components/ActiveCueItem.vue
+++ b/sbsp_frontend/src/components/ActiveCueItem.vue
@@ -14,7 +14,6 @@ import ProgressSpinnerWrapper from './wrapper/ProgressSpinnerWrapper.vue';
 
 const props = defineProps<{
   activeCue: ActiveCue;
-  isHidden: boolean;
 }>();
 
 const showModel = useShowModel();
@@ -40,7 +39,6 @@ const remainRef = useTemplateRef('remain');
 const progressRef = useTemplateRef('progress');
 
 usePosition((pos) => {
-  if (props.isHidden) return;
   if (elapsedRef.value == null || remainRef.value == null || progressRef.value == null) return;
   const position = pos[props.activeCue.cueId];
   if (position == null) return;

--- a/sbsp_frontend/src/components/pc/SideBar.vue
+++ b/sbsp_frontend/src/components/pc/SideBar.vue
@@ -29,13 +29,11 @@ const uiState = useUiState();
     </tab-list>
     <tab-panels class="grow overflow-auto p-0">
       <tab-panel value="activeCues">
-        <template
-          v-for="(activeCue, cue_id) in showState.activeCues"
-          :key="cue_id"
-        >
+        <template v-if="uiState.isRightSidebarOpen && uiState.sideBarTab === 'activeCues'">
           <active-cue-item
+            v-for="(activeCue, cue_id) in showState.activeCues"
+            :key="cue_id"
             :active-cue="activeCue"
-            :is-hidden="!uiState.isRightSidebarOpen || uiState.sideBarTab !== 'activeCues'"
           />
         </template>
       </tab-panel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved mobile panel rendering by loading only the currently selected list, controls, or monitor view.
  * Reduced unnecessary rendering of active cues when the sidebar is closed or another tab is selected.
* **Bug Fixes**
  * Active cue progress and elapsed/remaining time displays now update consistently while cues are active.
  * Simplified active cue display behavior across sidebar and mobile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->