### PR TITLE
fix(frontend): apply tabular-nums for time display

### DIFF
--- a/sbsp_frontend/src/MainViewMobile.vue
+++ b/sbsp_frontend/src/MainViewMobile.vue
@@ -40,12 +40,11 @@ watch(
         class="flex h-full w-full grow-0 items-center border border-(--p-form-field-border-color)"
       >
         <div
-          class="flex grow items-end justify-center pr-3 pl-3 text-center"
-          style="font-size: 4em; line-height: 1"
+          class="flex grow items-end justify-center pr-3 pl-3 text-center text-6xl tabular-nums"
         >
           <span>{{ String(time.getHours()).padStart(2, '0') }}</span
           >:<span>{{ String(time.getMinutes()).padStart(2, '0') }}</span
-          >.<span style="font-size: 32pt; line-height: 1">{{
+          >.<span class="text-4xl">{{
             String(time.getSeconds()).padStart(2, '0')
           }}</span>
         </div>

--- a/sbsp_frontend/src/components/ActiveCueItem.vue
+++ b/sbsp_frontend/src/components/ActiveCueItem.vue
@@ -75,7 +75,7 @@ usePosition((pos) => {
         size="21px"
       />
     </div>
-    <div class="flex flex-row justify-between p-0">
+    <div class="flex flex-row justify-between p-0 tabular-nums">
       <div
         ref="elapsed"
         class="px-3 py-2"

--- a/sbsp_frontend/src/components/mobile/CueListRow.vue
+++ b/sbsp_frontend/src/components/mobile/CueListRow.vue
@@ -107,7 +107,7 @@ const isStatusIn = (statusList: PlaybackStatus[]): boolean => {
     </td>
     <td
       headers="cuelist_number"
-      class="border-x border-(--p-form-field-border-color) px-1 text-center"
+      class="border-x border-(--p-form-field-border-color) px-1 text-center tabular-nums"
     >
       {{ item.cue.number }}
     </td>

--- a/sbsp_frontend/src/components/mobile/SeekBar.vue
+++ b/sbsp_frontend/src/components/mobile/SeekBar.vue
@@ -84,7 +84,7 @@ const onpointerup = () => {
       @pointerdown="sliderChanging = true"
       @pointerup="onpointerup"
     />
-    <div class="mt-2 flex flex-row">
+    <div class="mt-2 flex flex-row tabular-nums">
       <div
         ref="elapsed"
         class="mr-auto ml-0 px-1"

--- a/sbsp_frontend/src/components/pc/AppHeader.vue
+++ b/sbsp_frontend/src/components/pc/AppHeader.vue
@@ -95,12 +95,11 @@ const time = useNow();
         :class="hasFocus ? '' : 'bg-red-500'"
       >
         <div
-          class="flex items-end pr-3 pl-3 text-center"
-          style="font-size: 4em; line-height: 1"
+          class="flex items-end pr-3 pl-3 text-center text-6xl tabular-nums"
         >
           <span>{{ String(time.getHours()).padStart(2, '0') }}</span
           >:<span>{{ String(time.getMinutes()).padStart(2, '0') }}</span
-          >.<span style="font-size: 32pt; line-height: 1">{{
+          >.<span class="text-4xl">{{
             String(time.getSeconds()).padStart(2, '0')
           }}</span>
         </div>

--- a/sbsp_frontend/src/components/pc/CueListRow.vue
+++ b/sbsp_frontend/src/components/pc/CueListRow.vue
@@ -353,7 +353,7 @@ const isPlayingActive = computed((): boolean => {
     </td>
     <td
       headers="cuelist_number"
-      class="text-center"
+      class="text-center tabular-nums"
       @dblclick="openEditable($event, 'cuelist_number')"
       @blur="closeEditable($event.target, true, 'cuelist_number')"
       @keydown.enter.stop="closeEditable($event.target, true, 'cuelist_number')"
@@ -404,7 +404,7 @@ const isPlayingActive = computed((): boolean => {
           "
         />
         <div
-          class="absolute left-0 w-full text-center"
+          class="absolute left-0 w-full text-center tabular-nums"
           style="top: 50%; transform: translateY(-50%)"
           @dblclick="if (!isPreWaitActive) openEditable($event, 'cuelist_pre_wait');"
           @blur="closeEditable($event.target, true, 'cuelist_pre_wait')"
@@ -431,7 +431,7 @@ const isPlayingActive = computed((): boolean => {
           "
         />
         <div
-          class="absolute left-0 w-full text-center"
+          class="absolute left-0 w-full text-center tabular-nums"
           style="top: 50%; transform: translateY(-50%)"
           @dblclick="if (!isPlayingActive) openEditable($event, 'cuelist_duration');"
           @blur="closeEditable($event.target, true, 'cuelist_duration')"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved clock readability across mobile and desktop views with consistent sizing and alignment.
  * Standardized numeric displays for cue numbers, elapsed time, remaining time, pre-wait values, and durations.
  * Fixed-width numerals now reduce visual shifting as displayed values change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->