### PR TITLE
fix(backend): group stop behavier

### DIFF
--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -17,7 +17,6 @@ use crate::{
     event::BackendEvent,
     executor::{ExecutorCommand, ExecutorEvent, StopMode},
     manager::ShowModelHandle,
-    model::cue::CueParam,
 };
 
 pub struct CueController {
@@ -227,13 +226,9 @@ impl CueController {
             ControllerCommand::PauseAll
             | ControllerCommand::ResumeAll
             | ControllerCommand::StopAll => {
-                for (cue_id, active_cue) in &state.active_cues {
-                    let is_group = self
-                        .model_handle
-                        .get_cue_by_id(cue_id)
-                        .await
-                        .is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
-                    if !is_group {
+                let root_ids = self.model_handle.read().await.cue_list.root_ids.clone();
+                for cue_id in &root_ids {
+                    if let Some(active_cue) = state.active_cues.get(cue_id) {
                         let executor_command = match command {
                             ControllerCommand::PauseAll => match active_cue.status {
                                 PlaybackStatus::PreWaiting | PlaybackStatus::Playing => {
@@ -285,13 +280,9 @@ impl CueController {
 
     async fn hard_stop_all(&self) -> Result<()> {
         let state = self.state_tx.borrow().clone();
-        for cue_id in state.active_cues.keys() {
-            let is_group = self
-                .model_handle
-                .get_cue_by_id(cue_id)
-                .await
-                .is_some_and(|cue| matches!(cue.params, CueParam::Group { .. }));
-            if !is_group {
+        let root_ids = self.model_handle.read().await.cue_list.root_ids.clone();
+        for cue_id in &root_ids {
+            if state.active_cues.contains_key(cue_id) {
                 self.executor_tx
                     .send(ExecutorCommand::Stop(*cue_id, StopMode::Hard))
                     .await?;

--- a/sbsp_backend/src/executor.rs
+++ b/sbsp_backend/src/executor.rs
@@ -263,7 +263,16 @@ impl Executor {
                     }
                     ScopeContext::GroupPause => {}
                     ScopeContext::GroupResume => {}
-                    ScopeContext::GroupStop => {}
+                    ScopeContext::GroupStop => {
+                        self.executor_event_tx
+                            .send(ExecutorEvent::Stopping {
+                                cue_id,
+                                position: 0.0,
+                                duration: 0.0,
+                            })
+                            .await
+                            .ok();
+                    }
                     ScopeContext::Playback => {
                         self.active_instances.insert(
                             cue_id,
@@ -694,24 +703,36 @@ impl Executor {
                             }
                         }
                         CueParam::Group { .. } => {
-                            // TODO: check and fade decendants?
-                            let children = self
+                            let mut visited = HashSet::new();
+                            let mut queue = self
                                 .model_handle
                                 .get_all_children_by_id(&params.target)
                                 .await;
-                            for child in children {
-                                if self.active_instances.contains_key(&child.id)
-                                    && let CueParam::Audio(_) = child.params
-                                    && let Err(e) = self
-                                        .audio_tx
-                                        .send(AudioCommand::FadeVolume {
-                                            id: child.id,
-                                            volume: params.volume,
-                                            fade_param: params.fade_param,
-                                        })
-                                        .await
-                                {
-                                    log::error!("Failed to fade group child. e={}", e);
+
+                            while let Some(child) = queue.pop() {
+                                if !visited.insert(child.id) {
+                                    continue;
+                                }
+                                match &child.params {
+                                    CueParam::Audio(_) => {
+                                        if self.active_instances.contains_key(&child.id)
+                                            && let Err(e) = self
+                                                .audio_tx
+                                                .send(AudioCommand::FadeVolume {
+                                                    id: child.id,
+                                                    volume: params.volume,
+                                                    fade_param: params.fade_param,
+                                                })
+                                                .await
+                                        {
+                                            log::error!("Failed to fade group child. e={}", e);
+                                        }
+                                    }
+                                    CueParam::Group { .. } => {
+                                        let grandchildren = self.model_handle.get_all_children_by_id(&child.id).await;
+                                        queue.extend(grandchildren);
+                                    }
+                                    _ => {}
                                 }
                             }
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pause, resume, stop, and hard-stop commands now consistently affect active top-level cues.
  - Group stop actions now correctly report that the group is stopping.
  - Fading a group now applies to all active audio cues nested within it, including deeper descendants.
  - Improved handling prevents duplicate processing when cues are shared or referenced through multiple paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->