### PR TITLE
refactor(frontend): simplify cursor advance

### DIFF
--- a/sbsp_frontend/src/MainView.vue
+++ b/sbsp_frontend/src/MainView.vue
@@ -71,37 +71,20 @@ useBackendEvent((event) => {
             } else {
               cursorAdvanceTrigger = cue.cursorAdvanceTriggerOverride;
             }
+            if ((cursorAdvanceTrigger === 'onTriggered' && event.param.type === 'triggered') || (cursorAdvanceTrigger === 'onTriggered' && event.param.type === 'triggered')) {
+              let nextCursor;
+              if (
+                cue.params.type === 'group' &&
+                cue.params.mode.type === 'startFirst' &&
+                cue.params.mode.enter
+              ) {
+                nextCursor = cue.params.children[1] ?? showModel.getNextCueById(uiState.playbackCursor);
+              } else {
+                nextCursor = showModel.getNextCueById(uiState.playbackCursor);
+              }
+              uiState.setPlaybackCursor(nextCursor);
+            }
           }
-        }
-        if (cursorAdvanceTrigger === 'onTriggered' && event.param.type === 'triggered') {
-          const cue = showModel.getCueById(uiState.playbackCursor);
-          let nextCursor;
-          if (
-            cue != null &&
-            cue.params.type === 'group' &&
-            cue.params.mode.type === 'startFirst' &&
-            cue.params.mode.enter
-          ) {
-            nextCursor = cue.params.children[1] ?? showModel.getNextCueById(uiState.playbackCursor);
-          } else {
-            nextCursor = showModel.getNextCueById(uiState.playbackCursor);
-          }
-          uiState.setPlaybackCursor(nextCursor);
-        }
-        if (cursorAdvanceTrigger === 'onCompleted' && event.param.type === 'completed') {
-          const cue = showModel.getCueById(uiState.playbackCursor);
-          let nextCursor;
-          if (
-            cue != null &&
-            cue.params.type === 'group' &&
-            cue.params.mode.type === 'startFirst' &&
-            cue.params.mode.enter
-          ) {
-            nextCursor = cue.params.children[1] ?? showModel.getNextCueById(uiState.playbackCursor);
-          } else {
-            nextCursor = showModel.getNextCueById(uiState.playbackCursor);
-          }
-          uiState.setPlaybackCursor(nextCursor);
         }
       }
       showState.handleCueStateEvent(event.param);

--- a/sbsp_frontend/src/MainView.vue
+++ b/sbsp_frontend/src/MainView.vue
@@ -71,7 +71,7 @@ useBackendEvent((event) => {
             } else {
               cursorAdvanceTrigger = cue.cursorAdvanceTriggerOverride;
             }
-            if ((cursorAdvanceTrigger === 'onTriggered' && event.param.type === 'triggered') || (cursorAdvanceTrigger === 'onTriggered' && event.param.type === 'triggered')) {
+            if ((cursorAdvanceTrigger === 'onTriggered' && event.param.type === 'triggered') || (cursorAdvanceTrigger === 'onCompleted' && event.param.type === 'completed')) {
               let nextCursor;
               if (
                 cue.params.type === 'group' &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cue navigation during triggered events.
  * Ensured the current cue is resolved before advancing to the next cue.
  * Preserved expected advancement for grouped cues configured to start with their first child and enter the second child when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->