### PR TITLE
fix: hard stop all on load and reset ShowModel

### DIFF
--- a/sbsp_backend/src/controller.rs
+++ b/sbsp_backend/src/controller.rs
@@ -280,13 +280,10 @@ impl CueController {
 
     async fn hard_stop_all(&self) -> Result<()> {
         let state = self.state_tx.borrow().clone();
-        let root_ids = self.model_handle.read().await.cue_list.root_ids.clone();
-        for cue_id in &root_ids {
-            if state.active_cues.contains_key(cue_id) {
-                self.executor_tx
-                    .send(ExecutorCommand::Stop(*cue_id, StopMode::Hard))
-                    .await?;
-            }
+        for cue_id in state.active_cues.keys() {
+            self.executor_tx
+                .send(ExecutorCommand::Stop(*cue_id, StopMode::Hard))
+                .await?;
         }
         Ok(())
     }

--- a/sbsp_frontend/src/locales/en.json
+++ b/sbsp_frontend/src/locales/en.json
@@ -373,7 +373,8 @@
       "open": "Open",
       "save": "Save",
       "saveAs": "Save As...",
-      "title": "File"
+      "title": "File",
+      "warningBeforeLoadAndReset": "The active cue will be stopped. Do you want to proceed?"
     },
     "help": {
       "checkUpdate": "Check for updates",

--- a/sbsp_frontend/src/locales/ja.json
+++ b/sbsp_frontend/src/locales/ja.json
@@ -373,7 +373,8 @@
       "open": "開く",
       "save": "保存",
       "saveAs": "名前をつけて保存",
-      "title": "ファイル"
+      "title": "ファイル",
+      "warningBeforeLoadAndReset": "アクティブなキューが停止されます。続行しますか?"
     },
     "help": {
       "checkUpdate": "アップデートを確認",

--- a/sbsp_frontend/src/window-menu.ts
+++ b/sbsp_frontend/src/window-menu.ts
@@ -140,7 +140,7 @@ export const createWindowMenu = () => {
                 buttons: 'OkCancel',
                 kind: 'warning',
               });
-              if (result === 'Cancel') {
+              if (result !== 'Ok') {
                 return;
               }
             } catch (e) {
@@ -174,7 +174,7 @@ export const createWindowMenu = () => {
           } else {
             api.host?.fileNew();
           }
-        })();
+        })().catch((e) => console.error(e));
       },
     });
 
@@ -191,7 +191,7 @@ export const createWindowMenu = () => {
                 buttons: 'OkCancel',
                 kind: 'warning',
               });
-              if (result === 'Cancel') {
+              if (result !== 'Ok') {
                 return;
               }
             } catch (e) {
@@ -200,7 +200,7 @@ export const createWindowMenu = () => {
             }
           }
           api.host?.fileOpen();
-        })();
+        })().catch((e) => console.error(e));
       },
     });
 

--- a/sbsp_frontend/src/window-menu.ts
+++ b/sbsp_frontend/src/window-menu.ts
@@ -10,6 +10,7 @@ import { useUiSettings } from './stores/uiSettings';
 import { useApi } from './api';
 import { appLogDir } from '@tauri-apps/api/path';
 import { openPath } from '@tauri-apps/plugin-opener';
+import { useShowState } from './stores/showState';
 
 type MenuItemHolder = MenuItem | PredefinedMenuItem | null;
 
@@ -20,6 +21,7 @@ export const createWindowMenu = () => {
   const isMacOs = api.isMacOs();
   let connected = api.remote ? false : true;
   const uiState = useUiState();
+  const showState = useShowState();
   let mode: 'edit' | 'run' | 'view' = uiState.mode;
 
   const items = {
@@ -131,39 +133,48 @@ export const createWindowMenu = () => {
       text: t('menu.file.new'),
       enabled: __IS_HOST__,
       action: () => {
-        api.isModified().then((isModified) => {
+        (async () => {
+          if (Object.values(showState.activeCues).length > 0) {
+            try {
+              const result = await message(t('menu.file.warningBeforeLoadAndReset'), {
+                buttons: 'OkCancel',
+                kind: 'warning',
+              });
+              if (result === 'Cancel') {
+                return;
+              }
+            } catch (e) {
+              console.error(e);
+              return;
+            }
+          }
+          const isModified = await api.isModified();
           if (isModified) {
-            message(t('dialog.saveConfirm.content'), {
+            const result = await message(t('dialog.saveConfirm.content'), {
               buttons: {
                 yes: t('dialog.saveConfirm.save'),
                 no: t('dialog.saveConfirm.dontSave'),
                 cancel: t('dialog.saveConfirm.cancel'),
               },
-            })
-              .then((result) => {
-                switch (result) {
-                  case t('dialog.saveConfirm.save'):
-                    api.host
-                      ?.fileSave()
-                      .then((isSaved) => {
-                        if (isSaved) {
-                          api.host?.fileNew();
-                        }
-                      })
-                      .catch((e) => console.error(e));
-                    break;
-                  case t('dialog.saveConfirm.dontSave'):
-                    api.host?.fileNew();
-                    break;
-                  case t('dialog.saveConfirm.cancel'):
-                    break;
+            });
+            switch (result) {
+              case t('dialog.saveConfirm.save'): {
+                const isSaved = await api.host?.fileSave()
+                if (isSaved) {
+                  api.host?.fileNew();
                 }
-              })
-              .catch((e) => console.error(e));
+                break;
+              }
+              case t('dialog.saveConfirm.dontSave'):
+                api.host?.fileNew();
+                break;
+              case t('dialog.saveConfirm.cancel'):
+                break;
+            }
           } else {
             api.host?.fileNew();
           }
-        });
+        })();
       },
     });
 
@@ -173,7 +184,23 @@ export const createWindowMenu = () => {
       enabled: __IS_HOST__,
       accelerator: isMacOs ? '⌘ + O' : 'Ctrl + O',
       action: () => {
-        api.host?.fileOpen();
+        (async () => {
+          if (Object.values(showState.activeCues).length > 0) {
+            try {
+              const result = await message(t('menu.file.warningBeforeLoadAndReset'), {
+                buttons: 'OkCancel',
+                kind: 'warning',
+              });
+              if (result === 'Cancel') {
+                return;
+              }
+            } catch (e) {
+              console.error(e);
+              return;
+            }
+          }
+          api.host?.fileOpen();
+        })();
       },
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings before creating or opening a file when active cues are running.
  * Added localized English and Japanese messages explaining that active cues will be stopped.
  * New-file actions now confirm saving modified work before proceeding.

* **Bug Fixes**
  * Stopping all active cues now reliably stops every active cue, not only top-level cues.
  * Canceling a warning or encountering an error safely prevents the requested file operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->